### PR TITLE
Fix variable name in preload style helper

### DIFF
--- a/shoptimizer/preloadcss.php
+++ b/shoptimizer/preloadcss.php
@@ -261,7 +261,8 @@ function pwcc_filter_style_loader_tag( $tag, $handle, $href, $media ) {
 		return $tag;
 	}
 
-	$rel = isset( $obj->extra['alt'] ) && $obj->extra['alt'] ? 'alternate stylesheet' : 'stylesheet';
+        // Use the correct variable when checking for the 'alt' flag.
+        $rel = isset( $style->extra['alt'] ) && $style->extra['alt'] ? 'alternate stylesheet' : 'stylesheet';
 
 	$tag  = sprintf( '<noscript>%s</noscript>', $tag );
 	$tag .= sprintf(


### PR DESCRIPTION
## Summary
- fix undefined variable in preloadcss helper

## Testing
- `php -l shoptimizer/preloadcss.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859b470183c832a933aaee9e7ec92bd